### PR TITLE
'requests' dependency now has to be 2.24.0 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = [
     "pymongo[srv,tls] ~= 3.11.1",
     "docutils == 0.16",
     "watchdog ~= 0.10.3",
-    "requests ~= 2.24.0",
+    "requests >= 2.24.0",
     "toml ~= 0.10.1",
     "pyyaml ~= 5.3.1",
     "typing-extensions ~= 3.7.4.1",


### PR DESCRIPTION
Naiive attempt at fixing this error:

```
The conflict is caused by:
    The user requested requests==2.25.1
    google-api-core 1.24.1 depends on requests<3.0.0dev and >=2.18.0
    snooty-lextudio 1.8.6.dev0 depends on requests~=2.24.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

```